### PR TITLE
Tipo do retorno e import

### DIFF
--- a/Hasher/Hasher.py
+++ b/Hasher/Hasher.py
@@ -45,9 +45,3 @@ if __name__ == '__main__':
 	#else, help!
 	else:
 	    help()
-
-else:
-	#Not Supported. Work on it.
-	print("Module import not supported yet!")
-	#So, exiting
-	sys.exit(0)

--- a/Hasher/Hasher.py
+++ b/Hasher/Hasher.py
@@ -23,7 +23,7 @@ def hash_info(path):
 	sha256=""+str(hashlib.sha256(malwr).hexdigest())+""
 	sha384=""+str(hashlib.sha384(malwr).hexdigest())+""
 	sha512=""+str(hashlib.sha512(malwr).hexdigest())+""
-	return [("SSDEEP",hash_ssdeep),("CRC32",crc32),("MD5",md5),("SHA1",sha1),("SHA224",sha224),("SHA256",sha256),("SHA384",sha384),("SHA512",sha512)]
+	return {'SSDEEP':hash_ssdeep,'CRC32':crc32,'MD5':md5,'SHA1':sha1,'SHA224':sha224,'SHA256':sha256,'SHA384':sha384,'SHA512':sha512}
 
 # Help
 def help():
@@ -39,9 +39,9 @@ if __name__ == '__main__':
 	if(len(sys.argv)==2):
 	# when having args
             print("Hashes of %s" % sys.argv[1])
-	    hashes=hash_info(sys.argv[1])
-            for hash,val in hashes:
-                print("[%s]\t:\t%s" % (hash,val)).expandtabs(5)
+            hashes=hash_info(sys.argv[1])
+            for indice in hashes:
+                print("[%s]\t:\t%s" % (indice,hashes[indice])).expandtabs(5)
 	#else, help!
 	else:
 	    help()


### PR DESCRIPTION
Agora o módulo Hasher.py passa a retornar um dicionário. Aí fica mais fácil para acessar os hashes. Além disso, o mesmo módulo passa a funcionar com o import de outra lib(tanto para py2 quanto para py3).